### PR TITLE
26 create new game

### DIFF
--- a/.idea/final-project.iml
+++ b/.idea/final-project.iml
@@ -26,121 +26,97 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/cache" />
     </content>
-    <orderEntry type="jdk" jdkName="rbenv: 3.2.2" jdkType="RUBY_SDK" />
+    <orderEntry type="jdk" jdkName="3.2.2" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="actioncable (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionmailbox (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionmailer (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionpack (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actiontext (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionview (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activejob (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activemodel (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activerecord (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activestorage (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bcrypt (v3.1.20, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bigdecimal (v3.1.8, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bindex (v0.8.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bootsnap (v1.16.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.4.10, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="capybara (v3.39.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.2.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber (v9.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-ci-environment (v10.0.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-core (v13.0.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-cucumber-expressions (v17.1.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-gherkin (v27.0.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-html-formatter (v21.7.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-messages (v22.0.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-rails (v3.0.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="cucumber-tag-expressions (v6.1.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="database_cleaner-active_record (v2.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="database_cleaner-core (v2.0.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="debug (v1.8.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="devise (v4.9.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.5.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="docile (v1.4.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="erubi (v1.12.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="factory_bot (v6.5.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="factory_bot_rails (v6.4.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ffi (v1.17.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.1.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="importmap-rails (v1.2.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="io-console (v0.6.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="irb (v1.7.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="jbuilder (v2.11.5, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="json (v2.8.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="loofah (v2.21.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="mail (v2.8.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="matrix (v0.4.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.18.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.7.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="multi_test (v1.1.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.3.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="net-smtp (v0.3.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.5.9, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.15.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="orm_adapter (v0.5.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.26.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parser (v3.3.6.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v5.0.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="puma (v5.6.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="racc (v1.7.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rack (v2.2.7, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rack-test (v2.1.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rails (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v2.1.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.6.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="railties (v7.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.8.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="reline (v0.3.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="responders (v3.1.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.13.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.13.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.13.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-rails (v7.0.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.13.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.68.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.34.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-rails (v2.27.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.13.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.10.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.22.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.13.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov_json_formatter (v0.1.4, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sprockets (v4.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sprockets-rails (v3.4.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sqlite3 (v1.6.3, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="stimulus-rails (v1.2.1, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sys-uname (v1.3.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="thor (v1.2.2, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="timeout (v0.4.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="turbo-rails (v1.4.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.6.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="warden (v1.2.9, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="web-console (v4.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="webdrivers (v5.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="websocket (v1.2.9, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="websocket-driver (v0.7.5, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="websocket-extensions (v0.1.5, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="xpath (v3.2.0, rbenv: 3.2.2) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.6.8, rbenv: 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actioncable (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailbox (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailer (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionpack (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actiontext (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionview (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activejob (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activemodel (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activerecord (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activestorage (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.4, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bindex (v0.8.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bootsnap (v1.16.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.4.10, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="capybara (v3.39.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.2.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="debug (v1.8.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.5.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="erubi (v1.12.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot (v6.5.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot_rails (v6.4.4, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.1.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="importmap-rails (v1.2.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="io-console (v0.6.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="irb (v1.7.4, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="jbuilder (v2.11.5, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json (v2.8.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="loofah (v2.21.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mail (v2.8.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="matrix (v0.4.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.18.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.7.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.3.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-smtp (v0.3.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.5.9, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.15.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.26.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parser (v3.3.6.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v5.0.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="puma (v5.6.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="racc (v1.7.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack (v2.2.7, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack-test (v2.1.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v2.1.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.6.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="railties (v7.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.8.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="reline (v0.3.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.13.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.13.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.13.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-rails (v7.0.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.13.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.68.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.34.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-rails (v2.27.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.13.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.10.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sprockets (v4.2.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sprockets-rails (v3.4.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sqlite3 (v1.6.3, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="stimulus-rails (v1.2.1, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="thor (v1.2.2, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="timeout (v0.4.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="turbo-rails (v1.4.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.6.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="web-console (v4.2.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="webdrivers (v5.2.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket (v1.2.9, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket-driver (v0.7.5, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket-extensions (v0.1.5, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="xpath (v3.2.0, 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.6.8, 3.2.2) [gem]" level="application" />
   </component>
   <component name="RModuleSettingsStorage">
     <LOAD_PATH number="0" />
@@ -149,126 +125,76 @@
   <component name="RailsGeneratorsCache">
     <option name="generators">
       <list>
-        <option value="active_record:application_record" />
-        <option value="active_record:devise" />
-        <option value="active_record:multi_db" />
-        <option value="application_record" />
-        <option value="benchmark" />
-        <option value="channel" />
+        <option value="active_record:migration" />
+        <option value="active_record:model" />
+        <option value="active_record:observer" />
+        <option value="active_record:session_migration" />
         <option value="controller" />
-        <option value="cucumber:install" />
-        <option value="devise" />
-        <option value="devise:controllers" />
-        <option value="devise:install" />
-        <option value="devise:views" />
-        <option value="factory_bot:model" />
+        <option value="erb:controller" />
+        <option value="erb:mailer" />
+        <option value="erb:scaffold" />
         <option value="generator" />
         <option value="helper" />
         <option value="integration_test" />
-        <option value="jbuilder" />
-        <option value="job" />
-        <option value="mailbox" />
         <option value="mailer" />
+        <option value="metal" />
         <option value="migration" />
         <option value="model" />
-        <option value="mongoid:devise" />
+        <option value="model_subclass" />
+        <option value="observer" />
+        <option value="performance_test" />
+        <option value="plugin" />
         <option value="resource" />
-        <option value="responders:install" />
-        <option value="responders_controller" />
-        <option value="rspec:channel" />
-        <option value="rspec:controller" />
-        <option value="rspec:feature" />
-        <option value="rspec:generator" />
-        <option value="rspec:helper" />
-        <option value="rspec:install" />
-        <option value="rspec:job" />
-        <option value="rspec:mailbox" />
-        <option value="rspec:mailer" />
-        <option value="rspec:model" />
-        <option value="rspec:request" />
-        <option value="rspec:scaffold" />
-        <option value="rspec:system" />
-        <option value="rspec:view" />
         <option value="scaffold" />
         <option value="scaffold_controller" />
-        <option value="stimulus" />
-        <option value="system_test" />
-        <option value="task" />
-        <option value="test_unit:channel" />
+        <option value="session_migration" />
+        <option value="stylesheets" />
         <option value="test_unit:controller" />
-        <option value="test_unit:generator" />
         <option value="test_unit:helper" />
-        <option value="test_unit:install" />
         <option value="test_unit:integration" />
-        <option value="test_unit:job" />
-        <option value="test_unit:mailbox" />
         <option value="test_unit:mailer" />
         <option value="test_unit:model" />
+        <option value="test_unit:observer" />
+        <option value="test_unit:performance" />
         <option value="test_unit:plugin" />
         <option value="test_unit:scaffold" />
-        <option value="test_unit:system" />
       </list>
     </option>
     <option name="myGenerators">
       <list>
-        <option value="active_record:application_record" />
-        <option value="active_record:devise" />
-        <option value="active_record:multi_db" />
-        <option value="application_record" />
-        <option value="benchmark" />
-        <option value="channel" />
+        <option value="active_record:migration" />
+        <option value="active_record:model" />
+        <option value="active_record:observer" />
+        <option value="active_record:session_migration" />
         <option value="controller" />
-        <option value="cucumber:install" />
-        <option value="devise" />
-        <option value="devise:controllers" />
-        <option value="devise:install" />
-        <option value="devise:views" />
-        <option value="factory_bot:model" />
+        <option value="erb:controller" />
+        <option value="erb:mailer" />
+        <option value="erb:scaffold" />
         <option value="generator" />
         <option value="helper" />
         <option value="integration_test" />
-        <option value="jbuilder" />
-        <option value="job" />
-        <option value="mailbox" />
         <option value="mailer" />
+        <option value="metal" />
         <option value="migration" />
         <option value="model" />
-        <option value="mongoid:devise" />
+        <option value="model_subclass" />
+        <option value="observer" />
+        <option value="performance_test" />
+        <option value="plugin" />
         <option value="resource" />
-        <option value="responders:install" />
-        <option value="responders_controller" />
-        <option value="rspec:channel" />
-        <option value="rspec:controller" />
-        <option value="rspec:feature" />
-        <option value="rspec:generator" />
-        <option value="rspec:helper" />
-        <option value="rspec:install" />
-        <option value="rspec:job" />
-        <option value="rspec:mailbox" />
-        <option value="rspec:mailer" />
-        <option value="rspec:model" />
-        <option value="rspec:request" />
-        <option value="rspec:scaffold" />
-        <option value="rspec:system" />
-        <option value="rspec:view" />
         <option value="scaffold" />
         <option value="scaffold_controller" />
-        <option value="stimulus" />
-        <option value="system_test" />
-        <option value="task" />
-        <option value="test_unit:channel" />
+        <option value="session_migration" />
+        <option value="stylesheets" />
         <option value="test_unit:controller" />
-        <option value="test_unit:generator" />
         <option value="test_unit:helper" />
-        <option value="test_unit:install" />
         <option value="test_unit:integration" />
-        <option value="test_unit:job" />
-        <option value="test_unit:mailbox" />
         <option value="test_unit:mailer" />
         <option value="test_unit:model" />
+        <option value="test_unit:observer" />
+        <option value="test_unit:performance" />
         <option value="test_unit:plugin" />
         <option value="test_unit:scaffold" />
-        <option value="test_unit:system" />
       </list>
     </option>
   </component>

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'bootsnap', require: false
 gem 'devise'
 
 # Use Sass to process CSS
-# gem "sassc-rails"
+gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'warden'
 gem 'bootstrap', '~> 5.0.0'
 
 # Use Sass to process CSS
-gem "sassc-rails"
+gem 'sassc-rails'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -179,6 +180,8 @@ GEM
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.26.3)
@@ -283,6 +286,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.3-arm64-darwin)
+    sqlite3 (1.6.3-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     sys-uname (1.3.0)
@@ -318,6 +322,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,14 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -292,6 +300,7 @@ GEM
     sys-uname (1.3.0)
       ffi (~> 1.1)
     thor (1.2.2)
+    tilt (2.4.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -339,6 +348,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  sassc-rails
   selenium-webdriver
   simplecov
   sprockets-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -157,3 +157,26 @@
 .nav-link-signup:hover {
     background-color: #0056b3;
 }
+.button-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh; /* Full viewport height to center vertically */
+}
+
+.single-player-button {
+    font-size: 1.5em; /* Make the button text larger */
+    padding: 1em 2em; /* Add padding for a larger button */
+}
+.single-player-button {
+    font-size: 1.5em;
+    padding: 1em 2em;
+    transition: background-color 0.3s ease, transform 0.2s ease; /* Smooth transition */
+}
+
+/* Hover Effect */
+.single-player-button:hover {
+    background-color: #0056b3; /* Change the background color on hover */
+    color: #fff; /* Change the text color on hover */
+    transform: scale(1.05); /* Slightly increase size on hover */
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -180,3 +180,44 @@
     color: #fff; /* Change the text color on hover */
     transform: scale(1.05); /* Slightly increase size on hover */
 }
+.world-selection-box {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    max-width: 600px;
+    max-height: 400px;
+    overflow-y: auto;
+    padding: 15px;
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+}
+
+.world-card {
+    width: 100%;
+    max-width: 250px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #ffffff;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.world-card:hover {
+    transform: scale(1.05);
+    box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.world-card h3 {
+    margin: 0;
+    font-size: 1.2em;
+}
+
+.world-card p {
+    margin: 5px 0 0;
+    font-size: 0.9em;
+    color: #666;
+}
+

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,44 +1,42 @@
+# frozen_string_literal: true
+
 class GamesController < ApplicationController
   before_action :authenticate_user!
   def single_player
-    @saved_worlds = World.where(creator_id: current_user.id)  # Fetch saved worlds for the current user
+    @saved_worlds = World.where(creator_id: current_user.id) # Fetch saved worlds for the current user
   end
 
   def new_world
     @world = World.new
   end
 
-
   def create
-    @world = World.new(world_params)  # Use strong parameters to allow form input
+    @world = World.new(world_params)
     @world.creator_id = current_user.id
-    @world.name = 'New World' if @world.name.blank?  # Set default name if blank
+    @world.name = 'New World' if @world.name.blank? # Set default name if blank
 
     if @world.save
-      redirect_to single_player_path, notice: "World created successfully!"
+      redirect_to single_player_path, notice: 'World created successfully!'
     else
-      render :new_world, alert: "Error creating world."
+      render :new_world, alert: 'Error creating world.'
     end
   end
 
   def show
-    @world = World.find_by(id: params[:id])  # Ensure this matches the world ID and creator
-    Rails.logger.info "World object in show action: #{@world.inspect}"  # Log for debugging
+    @world = find_world
 
-    if @world.nil?
-      Rails.logger.info "World not found or does not belong to the current user."
-      redirect_to single_player_path, alert: "World not found."
-    end
+    return unless @world.nil?
+
+    redirect_to single_player_path, alert: 'World not found.'
   end
 
   private
 
-  def world_params
-    params.require(:world).permit(:name)  # Allow the name attribute (add more if needed)
+  def find_world
+    World.find_by(id: params[:id], creator_id: current_user.id)
   end
 
-
-
-
+  def world_params
+    params.require(:world).permit(:name)
+  end
 end
-

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,6 @@
+class GamesController < ApplicationController
+  def single_player
+    # Add any setup logic for the single-player mode here
+  end
+end
+

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,44 @@
 class GamesController < ApplicationController
+  before_action :authenticate_user!
   def single_player
-    # Add any setup logic for the single-player mode here
+    @saved_worlds = World.where(creator_id: current_user.id)  # Fetch saved worlds for the current user
   end
+
+  def new_world
+    @world = World.new
+  end
+
+
+  def create
+    @world = World.new(world_params)  # Use strong parameters to allow form input
+    @world.creator_id = current_user.id
+    @world.name = 'New World' if @world.name.blank?  # Set default name if blank
+
+    if @world.save
+      redirect_to single_player_path, notice: "World created successfully!"
+    else
+      render :new_world, alert: "Error creating world."
+    end
+  end
+
+  def show
+    @world = World.find_by(id: params[:id])  # Ensure this matches the world ID and creator
+    Rails.logger.info "World object in show action: #{@world.inspect}"  # Log for debugging
+
+    if @world.nil?
+      Rails.logger.info "World not found or does not belong to the current user."
+      redirect_to single_player_path, alert: "World not found."
+    end
+  end
+
+  private
+
+  def world_params
+    params.require(:world).permit(:name)  # Allow the name attribute (add more if needed)
+  end
+
+
+
+
 end
 

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class WorldsController < ApplicationController
 end

--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -1,0 +1,2 @@
+class WorldsController < ApplicationController
+end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,0 +1,2 @@
+module GamesHelper
+end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module GamesHelper
 end

--- a/app/helpers/worlds_helper.rb
+++ b/app/helpers/worlds_helper.rb
@@ -1,0 +1,2 @@
+module WorldsHelper
+end

--- a/app/helpers/worlds_helper.rb
+++ b/app/helpers/worlds_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module WorldsHelper
 end

--- a/app/models/world.rb
+++ b/app/models/world.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class World < ApplicationRecord
   belongs_to :creator, class_name: 'User', foreign_key: 'creator_id'
 end

--- a/app/models/world.rb
+++ b/app/models/world.rb
@@ -1,0 +1,3 @@
+class World < ApplicationRecord
+  belongs_to :creator, class_name: 'User', foreign_key: 'creator_id'
+end

--- a/app/views/games/new_world.html.erb
+++ b/app/views/games/new_world.html.erb
@@ -1,7 +1,7 @@
-<%= form_with model: @world, url: worlds_path, method: :post do |form| %>
+<%= form_with model: @world, url: worlds_path, method: :post, html: { id: 'new_world_form' } do |form| %>
   <div class="form-group">
     <%= form.label :name, "World Name" %>
-    <%= form.text_field :name, class: "form-control" %>
+    <%= form.text_field :name, class: "form-control", id: "world_name" %> <!-- Added ID here -->
   </div>
 
   <%= form.submit "Create World", class: "btn btn-primary" %>

--- a/app/views/games/new_world.html.erb
+++ b/app/views/games/new_world.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: @world, url: worlds_path, method: :post do |form| %>
+  <div class="form-group">
+    <%= form.label :name, "World Name" %>
+    <%= form.text_field :name, class: "form-control" %>
+  </div>
+
+  <%= form.submit "Create World", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,12 @@
+<!-- app/views/games/show.html.erb -->
+
+<% if @world %>
+  <h1>Welcome to <%= @world.name %>!</h1>
+  <p>Created on: <%= @world.created_at.strftime("%Y-%m-%d") %></p>
+  <p>Start your adventure in <%= @world.name %>.</p>
+<% else %>
+  <h1>World not found</h1>
+  <p>It seems that this world could not be loaded or does not belong to you.</p>
+  <p>Please return to the <%= link_to 'Single Player', single_player_path %> page and try again.</p>
+<% end %>
+

--- a/app/views/games/single_player.html.erb
+++ b/app/views/games/single_player.html.erb
@@ -1,2 +1,17 @@
-<h1>Welcome to Single Player Mode!</h1>
-<p>Prepare to start your journey in Shards of the Grid.</p>
+<h1>Select a World</h1>
+
+<!-- Selection Box for Worlds -->
+<div class="world-selection-box">
+  <% @saved_worlds.each do |world| %>
+    <div class="world-card" onclick="window.location.href='<%= game_path(world) %>'">
+      <h3><%= world.name %></h3>
+      <p>Created on: <%= world.created_at.strftime("%Y-%m-%d") %></p>
+    </div>
+  <% end %>
+</div>
+
+
+<!-- Create New World Button -->
+<div style="margin-top: 20px;">
+  <%= button_to 'Create New World', new_world_path, method: :get, class: 'btn btn-primary' %>
+</div>

--- a/app/views/games/single_player.html.erb
+++ b/app/views/games/single_player.html.erb
@@ -1,0 +1,2 @@
+<h1>Welcome to Single Player Mode!</h1>
+<p>Prepare to start your journey in Shards of the Grid.</p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,3 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<div class="button-container">
+  <%= button_to 'Single Player', single_player_path, method: :get, class: 'btn btn-primary btn-lg single-player-button' %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'single_player', to: 'games#single_player'
+  get 'new_world', to: 'games#new_world'
+  post 'worlds', to: 'games#create'
+  get 'games/:id', to: 'games#show', as: 'game'
+  resources :worlds, only: [:create]
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'home#index'
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
+  get 'single_player', to: 'games#single_player'
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,4 @@ Rails.application.routes.draw do
   get 'shards/purchase', to: 'shards#new', as: 'new_shards_purchase'
   post 'shards/purchase', to: 'shards#create', as: 'shards_purchase'
   post 'shards/fetch_rate', to: 'shards#fetch_rate'
-
 end

--- a/db/migrate/20241112232841_create_worlds.rb
+++ b/db/migrate/20241112232841_create_worlds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateWorlds < ActiveRecord::Migration[7.0]
   def change
     create_table :worlds do |t|

--- a/db/migrate/20241112232841_create_worlds.rb
+++ b/db/migrate/20241112232841_create_worlds.rb
@@ -1,0 +1,10 @@
+class CreateWorlds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :worlds do |t|
+      t.string :name
+      t.integer :creator_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 20_241_112_124_345) do
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'shards_balance'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
-
+ActiveRecord::Schema[7.0].define(version: 2024_11_12_232841) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "shards_balance"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "worlds", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_241_109_143_923) do
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+ActiveRecord::Schema[7.0].define(version: 2024_11_09_143923) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_09_143923) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_12_232841) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -19,8 +19,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_09_143923) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "shards_balance"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "worlds", force: :cascade do |t|
+    t.string "name"
+    t.integer "creator_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,25 +12,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_12_232841) do
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "shards_balance"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+ActiveRecord::Schema[7.0].define(version: 20_241_112_232_841) do
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'shards_balance'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  create_table "worlds", force: :cascade do |t|
-    t.string "name"
-    t.integer "creator_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'worlds', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'creator_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
-
 end

--- a/features/step_definitions/world_steps.rb
+++ b/features/step_definitions/world_steps.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Given('I am logged in as a user') do
+  @user = FactoryBot.create(:user)
+  login_as(@user, scope: :user)
+end
+
+Given(/^(?:I am on|I visit) the single player page$/) do
+  visit single_player_path
+end
+
+When('I fill in the world name field with {string}') do |world_name|
+  fill_in 'World Name', with: world_name
+end
+
+When('I leave {string} blank') do |field_label|
+  fill_in field_label, with: ''
+end
+
+Then('I should see {string} in the list of saved worlds') do |world_name|
+  expect(page).to have_css('.world-card', text: world_name)
+end
+
+Then('I should see the message {string}') do |message|
+  expect(page).to have_content(message)
+end
+
+Given('I have created worlds named {string} and {string}') do |world_a, world_b|
+  FactoryBot.create(:world, name: world_a, creator: @user)
+  FactoryBot.create(:world, name: world_b, creator: @user)
+end
+
+Given('there is a world created by another user with the name {string}') do |world_name|
+  other_user = FactoryBot.create(:user, email: 'other_user@example.com') # Specify a unique email
+  FactoryBot.create(:world, name: world_name, creator: other_user)
+end
+
+When('I attempt to visit the {string} page') do |world_name|
+  world = World.find_by(name: world_name)
+  visit game_path(world)
+end
+
+Then('I should be on the single player page') do
+  expect(current_path).to eq(single_player_path)
+end

--- a/features/worlds.feature
+++ b/features/worlds.feature
@@ -1,0 +1,34 @@
+Feature: Manage Worlds
+  As a user of Shards of the Grid
+  I want to create and view worlds
+  So that I can start a new game or continue an existing one
+
+  Background:
+    Given I am logged in as a user
+    And I am on the single player page
+
+  Scenario: Creating a new world with a custom name
+    When I click "Create New World"
+    And I fill in the world name field with "My Custom World"
+    And I press "Create World"
+    Then I should see "World created successfully!"
+    And I should see "My Custom World" in the list of saved worlds
+
+  Scenario: Creating a new world with a blank name
+    When I click "Create New World"
+    And I leave "World Name" blank
+    And I press "Create World"
+    Then I should see "World created successfully!"
+    And I should see "New World" in the list of saved worlds
+
+  Scenario: Viewing saved worlds
+    Given I have created worlds named "World A" and "World B"
+    When I visit the single player page
+    Then I should see "World A" in the list of saved worlds
+    And I should see "World B" in the list of saved worlds
+
+  Scenario: Trying to view a world that does not belong to the user
+    Given there is a world created by another user with the name "Forbidden World"
+    When I attempt to visit the "Forbidden World" page
+    Then I should see "World not found."
+    And I should be on the single player page

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,19 +1,59 @@
+# frozen_string_literal: true
+
 # spec/controllers/games_controller_spec.rb
 require 'rails_helper'
 
 RSpec.describe GamesController, type: :controller do
-  let(:user) { create(:user) }  # Assuming a user factory or fixture is available
+  let(:user) { create(:user) }
+  let!(:world) { create(:world, creator_id: user.id) }
 
   before do
-    sign_in user  # Using Devise helper if Devise is used for authentication
+    sign_in user
+  end
+  describe 'GET #single_player' do
+    it 'assigns @saved_worlds and renders the single_player template' do
+      get :single_player
+
+      expect(assigns(:saved_worlds)).to eq([world]) # Check that @saved_worlds is assigned correctly
+      expect(response).to render_template(:single_player) # Ensure it renders the correct template
+    end
   end
 
+  describe 'GET #new_world' do
+    it 'initializes a new world instance and renders the new_world template' do
+      get :new_world
+
+      expect(assigns(:world)).to be_a_new(World)
+      expect(response).to render_template(:new_world)
+    end
+  end
+
+  describe 'GET #show' do
+    context 'when the world exists and belongs to the user' do
+      it 'assigns @world and renders the show template' do
+        get :show, params: { id: world.id }
+
+        expect(assigns(:world)).to eq(world)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when the world does not exist or does not belong to the user' do
+      it 'redirects to single_player_path with an alert message' do
+        get :show, params: { id: 9999 }
+
+        expect(assigns(:world)).to be_nil
+        expect(response).to redirect_to(single_player_path)
+        expect(flash[:alert]).to eq('World not found.')
+      end
+    end
+  end
   describe 'POST #create' do
     context 'with a provided name' do
       it 'creates a new world with the specified name' do
-        expect {
+        expect do
           post :create, params: { world: { name: 'My Custom World' } }
-        }.to change(World, :count).by(1)
+        end.to change(World, :count).by(1)
 
         created_world = World.last
         expect(created_world.name).to eq('My Custom World')
@@ -29,9 +69,9 @@ RSpec.describe GamesController, type: :controller do
 
     context 'with a blank name' do
       it 'creates a new world with the default name "Default World"' do
-        expect {
+        expect do
           post :create, params: { world: { name: '' } }
-        }.to change(World, :count).by(1)
+        end.to change(World, :count).by(1)
 
         created_world = World.last
         expect(created_world.name).to eq('New World')
@@ -47,13 +87,13 @@ RSpec.describe GamesController, type: :controller do
 
     context 'when world creation fails' do
       before do
-        allow_any_instance_of(World).to receive(:save).and_return(false)  # Mock failure of save
+        allow_any_instance_of(World).to receive(:save).and_return(false)
       end
 
       it 'does not create a new world' do
-        expect {
+        expect do
           post :create, params: { world: { name: 'My Custom World' } }
-        }.not_to change(World, :count)
+        end.not_to change(World, :count)
       end
 
       it 'renders the new world template with an error message' do

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,0 +1,65 @@
+# spec/controllers/games_controller_spec.rb
+require 'rails_helper'
+
+RSpec.describe GamesController, type: :controller do
+  let(:user) { create(:user) }  # Assuming a user factory or fixture is available
+
+  before do
+    sign_in user  # Using Devise helper if Devise is used for authentication
+  end
+
+  describe 'POST #create' do
+    context 'with a provided name' do
+      it 'creates a new world with the specified name' do
+        expect {
+          post :create, params: { world: { name: 'My Custom World' } }
+        }.to change(World, :count).by(1)
+
+        created_world = World.last
+        expect(created_world.name).to eq('My Custom World')
+        expect(created_world.creator_id).to eq(user.id)
+      end
+
+      it 'redirects to the single player path with a success message' do
+        post :create, params: { world: { name: 'My Custom World' } }
+        expect(response).to redirect_to(single_player_path)
+        expect(flash[:notice]).to eq('World created successfully!')
+      end
+    end
+
+    context 'with a blank name' do
+      it 'creates a new world with the default name "Default World"' do
+        expect {
+          post :create, params: { world: { name: '' } }
+        }.to change(World, :count).by(1)
+
+        created_world = World.last
+        expect(created_world.name).to eq('New World')
+        expect(created_world.creator_id).to eq(user.id)
+      end
+
+      it 'redirects to the single player path with a success message' do
+        post :create, params: { world: { name: '' } }
+        expect(response).to redirect_to(single_player_path)
+        expect(flash[:notice]).to eq('World created successfully!')
+      end
+    end
+
+    context 'when world creation fails' do
+      before do
+        allow_any_instance_of(World).to receive(:save).and_return(false)  # Mock failure of save
+      end
+
+      it 'does not create a new world' do
+        expect {
+          post :create, params: { world: { name: 'My Custom World' } }
+        }.not_to change(World, :count)
+      end
+
+      it 'renders the new world template with an error message' do
+        post :create, params: { world: { name: '' } }
+        expect(response).to render_template(:new_world)
+      end
+    end
+  end
+end

--- a/spec/factories/worlds.rb
+++ b/spec/factories/worlds.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :world do
-    name { "MyString" }
+    name { 'MyString' }
     creator_id { 1 }
   end
 end

--- a/spec/factories/worlds.rb
+++ b/spec/factories/worlds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :world do
+    name { "MyString" }
+    creator_id { 1 }
+  end
+end

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GamesHelper. For example:
+#
+# describe GamesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GamesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/worlds_helper_spec.rb
+++ b/spec/helpers/worlds_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/spec/helpers/worlds_helper_spec.rb
+++ b/spec/helpers/worlds_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the WorldsHelper. For example:
+#
+# describe WorldsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe WorldsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/world_spec.rb
+++ b/spec/models/world_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe World, type: :model do

--- a/spec/models/world_spec.rb
+++ b/spec/models/world_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe World, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Games", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Games", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Games', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/worlds_spec.rb
+++ b/spec/requests/worlds_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Worlds", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Worlds', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/worlds_spec.rb
+++ b/spec/requests/worlds_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Worlds", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
This PR introduces the "Create New Game" feature, allowing users to create new game instances (worlds) in Shards of the Grid. Users can now initiate a new game with customizable world names, with a fallback to the default name "New World" if no name is provided. Additionally, the functionality ensures that each world is associated with the currently logged-in user.

Key Changes
GamesController create action:

Implements the create action to handle game creation requests.
Associates each new world with the current_user as the creator.
Sets the world’s name to "New World" if no name is provided.
Redirects the user to the single-player view on successful creation, with a success message.
Redirects the user to the single-player view on failure, with an error message.
Routing:

Added a new route for creating a world to allow users to initiate new game instances.
UI Updates:

Added a "Create New World" button to the single-player page to facilitate easy access to game creation.
Updated the single-player page to display existing worlds in a list for user selection.

\

https://github.com/user-attachments/assets/54af5fc6-d959-4dfc-9542-9ec9c9e679fc

